### PR TITLE
HF20 complications and Analysis development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?

--- a/helperblock.js
+++ b/helperblock.js
@@ -41,3 +41,14 @@ function blocksToMidnight(firstDate, secondDate, secondsPerBlock) {
 }
 
 module.exports.blocksToMidnight = blocksToMidnight;
+
+
+
+// Function translates date into new date based on date-and-hour only (i.e. no minutes or seconds)
+// ------------------------------------------------------------------------------------------------------
+function UTCDateHourOnly(localDate) {
+    let hourOnlyDate = new Date(Date.UTC(localDate.getUTCFullYear(), localDate.getUTCMonth(), localDate.getUTCDate(), localDate.getUTCHours()));
+    return hourOnlyDate;
+}
+
+module.exports.UTCDateHourOnly = UTCDateHourOnly;

--- a/postprocessing.js
+++ b/postprocessing.js
@@ -1,61 +1,158 @@
 const Json2csvParser = require('json2csv').Parser;
 const fs = require('fs');
 
+
+
 // Postprocessing of marketshare report based on data extracted from MongoDB
 // -------------------------------------------------------------------------
-function marketShareProcessing(summary) {
-    otherData = {authors: 0, posts: 0, author_payout_sbd: 0, author_payout_steem: 0, author_payout_vests: 0, benefactor_payout_vests: 0, curator_payout_vests: 0, application: 'other'};
-    for (var i = summary.length - 1; i > -1 ; i-=1) {
-        summary[i].application = summary[i]._id.application;
-        delete summary[i]._id;
-        summary[i].author_payout_sbd = Number(summary[i].author_payout_sbd.toFixed(3));
-        summary[i].author_payout_steem = Number(summary[i].author_payout_steem.toFixed(3));
-        summary[i].author_payout_vests = Number(summary[i].author_payout_vests.toFixed(6));
-        summary[i].benefactor_payout_vests = Number(summary[i].benefactor_payout_vests.toFixed(6));
-        summary[i].curator_payout_vests = Number(summary[i].curator_payout_vests.toFixed(6));
+function marketShareProcessing(createdSummary, payoutSummary) {
+    let combinedSummary = [];
+    let blankPayoutRecord = {
+                  author_payout_sbd: 0, author_payout_steem: 0, author_payout_vests: 0, benefactor_payout_vests: 0, curator_payout_vests: 0,
+                  author_payout_sbd_STU: 0, author_payout_steem_STU: 0, author_payout_vests_STU: 0, benefactor_payout_vests_STU: 0, curator_payout_vests_STU: 0,
+                    };
+    let otherData = Object.assign({application: 'other', authors: 0, posts: 0}, blankPayoutRecord);
 
-        if (summary[i].application == '' || summary[i].application == ' ' || summary[i].application == null || summary[i].application == "null" || summary[i].application == "other") {
-            otherData.authors += summary[i].authors;
-            otherData.posts += summary[i].posts;
-            otherData.author_payout_sbd += summary[i].author_payout_sbd;
-            otherData.author_payout_steem += summary[i].author_payout_steem;
-            otherData.author_payout_vests += summary[i].author_payout_vests;
-            otherData.benefactor_payout_vests += summary[i].benefactor_payout_vests;
-            otherData.curator_payout_vests += summary[i].curator_payout_vests;
-            summary.splice(i,1);
+    for (var i = 0; i < createdSummary.length; i+=1) {
+        let payoutMatch = -1;
+        let combinedRecord = {};
+        for (var j = 0; j < payoutSummary.length; j+=1) {
+            if ( createdSummary[i]._id.application == payoutSummary[j]._id.application ) {
+                payoutMatch = j;
+                payoutSummary[j].match = true;
+            }
+        }
+        if (payoutMatch != -1) {
+            combinedRecord =  { application: createdSummary[i]._id.application,
+                                authors: createdSummary[i].authors,
+                                posts: createdSummary[i].posts,
+                                author_payout_sbd: Number(payoutSummary[payoutMatch].author_payout_sbd.toFixed(3)),
+                                author_payout_steem: Number(payoutSummary[payoutMatch].author_payout_steem.toFixed(3)),
+                                author_payout_vests: Number(payoutSummary[payoutMatch].author_payout_vests.toFixed(3)),
+                                benefactor_payout_sbd: Number(payoutSummary[payoutMatch].benefactor_payout_sbd.toFixed(3)),
+                                benefactor_payout_steem: Number(payoutSummary[payoutMatch].benefactor_payout_steem.toFixed(3)),
+                                benefactor_payout_vests: Number(payoutSummary[payoutMatch].benefactor_payout_vests.toFixed(3)),
+                                curator_payout_vests: Number(payoutSummary[payoutMatch].curator_payout_vests.toFixed(3)),
+                                author_payout_sbd_STU: Number(payoutSummary[payoutMatch].author_payout_sbd_STU.toFixed(3)),
+                                author_payout_steem_STU: Number(payoutSummary[payoutMatch].author_payout_steem_STU.toFixed(3)),
+                                author_payout_vests_STU: Number(payoutSummary[payoutMatch].author_payout_vests_STU.toFixed(3)),
+                                benefactor_payout_sbd_STU: Number(payoutSummary[payoutMatch].benefactor_payout_sbd_STU.toFixed(3)),
+                                benefactor_payout_steem_STU: Number(payoutSummary[payoutMatch].benefactor_payout_steem_STU.toFixed(3)),
+                                benefactor_payout_vests_STU: Number(payoutSummary[payoutMatch].benefactor_payout_vests_STU.toFixed(3)),
+                                curator_payout_vests_STU: Number(payoutSummary[payoutMatch].curator_payout_vests_STU.toFixed(3)),
+                              }
+        } else {
+            combinedRecord = Object.assign({ application: createdSummary[i]._id.application,
+                                authors: createdSummary[i].authors,
+                                posts: createdSummary[i].posts,
+                              }, blankPayoutRecord);
+        }
+        combinedSummary.push(combinedRecord);
+    }
+
+    for (let app of payoutSummary) {
+        if (!(app.hasOwnProperty('match'))) {
+            let combinedRecord = {  application: app._id.application,
+                                    authors: 0,
+                                    posts: 0,
+                                    author_payout_sbd: Number(app.author_payout_sbd.toFixed(3)),
+                                    author_payout_steem: Number(app.author_payout_steem.toFixed(3)),
+                                    author_payout_vests: Number(app.author_payout_vests.toFixed(3)),
+                                    benefactor_payout_sbd: Number(app.benefactor_payout_sbd.toFixed(3)),
+                                    benefactor_payout_steem: Number(app.benefactor_payout_steem.toFixed(3)),
+                                    benefactor_payout_vests: Number(app.benefactor_payout_vests.toFixed(3)),
+                                    curator_payout_vests: Number(app.curator_payout_vests.toFixed(3)),
+                                    author_payout_sbd_STU: Number(app.author_payout_sbd_STU.toFixed(3)),
+                                    author_payout_steem_STU: Number(app.author_payout_steem_STU.toFixed(3)),
+                                    author_payout_vests_STU: Number(app.author_payout_vests_STU.toFixed(3)),
+                                    benefactor_payout_sbd_STU: Number(app.benefactor_payout_sbd_STU.toFixed(3)),
+                                    benefactor_payout_steem_STU: Number(app.benefactor_payout_steem_STU.toFixed(3)),
+                                    benefactor_payout_vests_STU: Number(app.benefactor_payout_vests_STU.toFixed(3)),
+                                    curator_payout_vests_STU: Number(app.curator_payout_vests_STU.toFixed(3)),
+                                  }
+            combinedSummary.push(combinedRecord);
+        }
+    }
+
+    for (var k = combinedSummary.length - 1; k > -1 ; k-=1) {
+        if (combinedSummary[k].application == '' || combinedSummary[k].application == ' ' || combinedSummary[k].application == null || combinedSummary[k].application == "null" || combinedSummary[k].application == "other") {
+            otherData.authors += combinedSummary[k].authors;
+            otherData.posts += combinedSummary[k].posts;
+            otherData.author_payout_sbd += combinedSummary[k].author_payout_sbd;
+            otherData.author_payout_steem += combinedSummary[k].author_payout_steem;
+            otherData.author_payout_vests += combinedSummary[k].author_payout_vests;
+            otherData.benefactor_payout_vests += combinedSummary[k].benefactor_payout_vests;
+            otherData.curator_payout_vests += combinedSummary[k].curator_payout_vests;
+            otherData.author_payout_sbd_STU += combinedSummary[k].author_payout_sbd_STU;
+            otherData.author_payout_steem_STU += combinedSummary[k].author_payout_steem_STU;
+            otherData.author_payout_vests_STU += combinedSummary[k].author_payout_vests_STU;
+            otherData.benefactor_payout_vests_STU += combinedSummary[k].benefactor_payout_vests_STU;
+            otherData.curator_payout_vests_STU += combinedSummary[k].curator_payout_vests_STU;
+            combinedSummary.splice(k,1);
         }
     }
 
     ranking('authors', 'Desc');
     ranking('posts', 'Desc' );
 
-    summary.push(otherData);
-    for (var i = 0; i < summary.length; i+=1) {
-        console.log(summary[i])
+    combinedSummary.push(otherData);
+    for (var l = 0; l < combinedSummary.length; l+=1) {
+        console.log(combinedSummary[l])
     }
-    return summary;
+    return combinedSummary;
 
     function ranking(rankItem, rankOrder) {
-            let rankingArray = [];
-            let sortedArray = [];
-            for (var j = 0; j < summary.length; j+=1) {
-                rankingArray.push(summary[j][rankItem]);
-            }
-            if (rankOrder == 'Desc') {
-                sortedArray = rankingArray.slice().sort(function(a,b){return b-a});
-            } else {
-                sortedArray = rankingArray.slice().sort(function(a,b){return a-b});
-            }
-            let finalRanks = rankingArray.slice().map(function(c){return sortedArray.indexOf(c)+1});
-            let outputItem = rankItem + 'Rank'
-            for (var k = 0; k < summary.length; k+=1) {
-                summary[k][outputItem] = finalRanks[k];
-            }
-            return finalRanks;
+        let rankingArray = [];
+        let sortedArray = [];
+        for (var m = 0; m < combinedSummary.length; m+=1) {
+            rankingArray.push(combinedSummary[m][rankItem]);
         }
+        if (rankOrder == 'Desc') {
+            sortedArray = rankingArray.slice().sort(function(a,b){return b-a});
+        } else {
+            sortedArray = rankingArray.slice().sort(function(a,b){return a-b});
+        }
+        let finalRanks = rankingArray.slice().map(function(c){return sortedArray.indexOf(c)+1});
+        let outputItem = rankItem + 'Rank'
+        for (var n = 0; n < combinedSummary.length; n+=1) {
+            combinedSummary[n][outputItem] = finalRanks[n];
+        }
+        return finalRanks;
+    }
 }
 
 module.exports.marketShareProcessing = marketShareProcessing;
+
+
+
+// Postprocessing of marketshare report based on data extracted from MongoDB
+// -------------------------------------------------------------------------
+function productionStatsByDayProcessing(summary) {
+
+    for (let day of summary) {
+          day.date = day._id.dateDay;
+          delete day._id;
+          day.author_payout_sbd = Number(day.author_payout_sbd.toFixed(3));
+          day.author_payout_steem = Number(day.author_payout_steem.toFixed(3));
+          day.author_payout_vests = Number(day.author_payout_vests.toFixed(3));
+          day.benefactor_payout_sbd = Number(day.author_payout_sbd.toFixed(3));
+          day.benefactor_payout_steem = Number(day.author_payout_steem.toFixed(3));
+          day.benefactor_payout_vests = Number(day.benefactor_payout_vests.toFixed(3));
+          day.curator_payout_vests = Number(day.curator_payout_vests.toFixed(3));
+          day.author_payout_sbd_STU = Number(day.author_payout_sbd_STU.toFixed(3));
+          day.author_payout_steem_STU = Number(day.author_payout_steem_STU.toFixed(3));
+          day.author_payout_vests_STU = Number(day.author_payout_vests_STU.toFixed(3));
+          day.benefactor_payout_sbd_STU = Number(day.benefactor_payout_sbd_STU.toFixed(3));
+          day.benefactor_payout_steem_STU = Number(day.benefactor_payout_steem_STU.toFixed(3));
+          day.benefactor_payout_vests_STU = Number(day.benefactor_payout_vests_STU.toFixed(3));
+          day.curator_payout_vests_STU = Number(day.curator_payout_vests_STU.toFixed(3));
+    }
+
+    return summary;
+
+}
+
+module.exports.productionStatsByDayProcessing = productionStatsByDayProcessing;
 
 
 

--- a/steemdata.js
+++ b/steemdata.js
@@ -1,0 +1,7 @@
+
+
+bidbotArray = [ "postpromoter", "upmewhale", "therising", "brupvoter", "emperorofnaps", "booster", "brandonfyre",
+                    "oceanwhale", "minnowvotes", "smartsteem", "buildawhale", "rocky1", "sneaky-ninja", "jerrybanfield",
+                    "boomerang", "inciter", "appreciator", "upme", "jeck1", "promobot", "tipu", "bdvoter", "treeplanter", "lays"]
+
+module.exports.bidbotArray = bidbotArray;

--- a/steemrequest/steemrequest.js
+++ b/steemrequest/steemrequest.js
@@ -144,8 +144,10 @@ function getOpsAppBase(localBlockNo, processOps) {
     let options = {
         url: url20,
         method: 'POST',
-        body: dataString
+        body: dataString,
+        //timeout: 500
     }
+
     request(options, function(error, response, body) {
         processOps(error, response, body, localBlockNo);
     });
@@ -168,7 +170,7 @@ function getActiveVotes(localAuthor, localPermlink) {
 
     return requestPromise(options)
         .catch(function(error) {
-            console.log('Error in steemrequest.getActiveVotes:', 'Error name:',  error.name, 'Error message:', error.message, 'API params:', error.options.body); 
+            console.log('Error in steemrequest.getActiveVotes:', 'Error name:',  error.name, 'Error message:', error.message, 'API params:', error.options.body);
         });
 }
 


### PR DESCRIPTION
PR brings block.ops to the point where the data collection and translation process is complete for comments (incl posts), votes, and all three virtual ops reward types (author, curator, benefactor) for HF19 and HF20 (previous HF will still need to be studied). All complications are now thought to be covered.

Three main analyses now available (plus some smaller ones):
* Histograms of vote timing plus curation rewards vs upvote value for each bucket
* Market Share / Steem dApps analysis (including overall stats per day)
* Curators analysis (top curators per period, top votes per day, individual's votes analysis)


See individual commits for more details.
